### PR TITLE
Added an option to ignore www subdomains (instead of redirecting)

### DIFF
--- a/lib/subdomain.js
+++ b/lib/subdomain.js
@@ -32,13 +32,11 @@ module.exports = function(options) {
     };
 
     // subdomain specific middleware
-    if (host === options.base || host === 'localhost:8000') {
-      // not a subdomain
+    if (host === options.base || host === 'localhost:8000'
+        || (options.ignoreWWW && /^www\./.test(host))) {
+      // not a subdomain or ignoring www subdomain
       next();
     } else {
-      if(options.ignoreWWW && /^www\./.test(host)){
-        return next();
-      }
       // test for subdomain
       var matches = host.match(new RegExp('(.*)\.' + options.base));
       // subdomain


### PR DESCRIPTION
Added an optional ignoreWWW parameter. When enabled, subdomain will ignore www subdomains without removing them and redirecting.

My use case for this is a web app that dynamically handles customer subdomains and routes www traffic.

Here's an example:

```
app.use(subdomain({base: 'basedomain.tld', ignoreWWW: true}));
app.get('/subdomain/:subdomain/', function(req,res,next){
     console.log(req.params.subdomain);
     //do something based on the subdomain
     next();
});
app.get('/', function(req,res,next){
   // either the base domain, or www subdomain
   next(); 
});
```
